### PR TITLE
Update cell cycle metric to handle ENSEMBL IDs

### DIFF
--- a/bin/dataset-tirosh-genes.R
+++ b/bin/dataset-tirosh-genes.R
@@ -1,0 +1,122 @@
+#!/usr/bin/env Rscript
+
+"
+Download the Tirosh cell cycle genes
+
+Usage:
+    dataset-tirosh-genes.R --out-file=<path> [options]
+
+Options:
+    -h --help             Show this screen.
+    --out-file=<path>     Path to output file.
+" -> doc
+
+#' Get the Tirosh cell cycle genes
+#'
+#' Download the genes from the scIB repository and use {biomaRt} to add
+#' ENSEMBL gene symbols.
+#'
+#' @returns data.frame with Tirosh cell cycle genes
+get_tirosh_genes <- function() {
+
+    # Base URL for the scIB repository
+    base_url <- "https://raw.githubusercontent.com/theislab/scib/cce7aaa65ccc18649e141e30464361d1fc67ea77/scib/resources/"
+
+    # Files containing the Tirosh cell cycle genes
+    files <- c(
+        mouse_G2M = "g2m_genes_tirosh.txt",
+        human_G2M = "g2m_genes_tirosh_hm.txt",
+        mouse_S   = "s_genes_tirosh.txt",
+        human_S   = "s_genes_tirosh_hm.txt"
+    )
+
+    message("Reading gene set files...")
+    gene_sets <- lapply(files, function(.file) {
+        url <- paste0(base_url, .file)
+        message("Reading '", url, "'...")
+        read.table(url, header = FALSE, col.names = "Gene")
+    })
+    names(gene_sets) <- names(files)
+
+    message("Getting human gene annotations...")
+    # Get the human mart
+    human_mart <- biomaRt::useEnsembl("ensembl","hsapiens_gene_ensembl")
+
+    # Get the annotations for the human genes
+    human_annot <- biomaRt::getBM(
+        attributes = c("ensembl_gene_id","hgnc_symbol"),
+        filters    = "hgnc_symbol",
+        values     = c(gene_sets$human_G2M$Gene, gene_sets$human_S$Gene),
+        mart       = human_mart
+    )
+    # Remove any duplicates
+    human_annot <- human_annot[!duplicated(human_annot), ]
+
+    # Create a vector mapping the gene names to ENSEMBL gene symbols
+    human_map <- human_annot$ensembl_gene_id
+    names(human_map) <- human_annot$hgnc_symbol
+
+    message("Adding human gene annotations...")
+    # Alse set phase and species
+    gene_sets$human_G2M$ENSEMBL <- human_map[gene_sets$human_G2M$Gene]
+    gene_sets$human_G2M$Phase   <- "G2M"
+    gene_sets$human_G2M$Species <- "Human"
+    gene_sets$human_S$ENSEMBL   <- human_map[gene_sets$human_S$Gene]
+    gene_sets$human_S$Phase     <- "S"
+    gene_sets$human_S$Species   <- "Human"
+
+    message("Getting mouse gene annotations...")
+    # Get the human mart
+    mouse_mart <- biomaRt::useEnsembl("ensembl","mmusculus_gene_ensembl")
+
+    # Get the annotations for the human genes
+    mouse_annot <- biomaRt::getBM(
+        attributes = c("ensembl_gene_id","mgi_symbol"),
+        filters    = "mgi_symbol",
+        values     = c(gene_sets$mouse_G2M$Gene, gene_sets$mouse_S$Gene),
+        mart       = mouse_mart
+    )
+    # Remove any duplicates
+    mouse_annot <- mouse_annot[!duplicated(mouse_annot), ]
+
+    # Create a vector mapping the gene names to ENSEMBL gene symbols
+    mouse_map <- mouse_annot$ensembl_gene_id
+    names(mouse_map) <- mouse_annot$mgi_symbol
+
+    message("Adding mouse gene annotations...")
+    # Alse set phase and species
+    gene_sets$mouse_G2M$ENSEMBL <- mouse_map[gene_sets$mouse_G2M$Gene]
+    gene_sets$mouse_G2M$Phase   <- "G2M"
+    gene_sets$mouse_G2M$Species <- "Mouse"
+    gene_sets$mouse_S$ENSEMBL   <- mouse_map[gene_sets$mouse_S$Gene]
+    gene_sets$mouse_S$Phase     <- "S"
+    gene_sets$mouse_S$Species   <- "Mouse"
+
+    message("Creating final data.frame...")
+    tirosh_genes <- do.call(rbind, gene_sets)
+
+    return(tirosh_genes)
+}
+
+#' The main script function
+main <- function() {
+    args <- docopt::docopt(doc)
+
+    file <- args[["<file>"]]
+    out_file <- args[["--out-file"]]
+
+    output <- get_tirosh_genes()
+    message("Writing output to '", out_file, "'...")
+    write.table(
+        output,
+        file      = out_file,
+        quote     = FALSE,
+        sep       = "\t",
+        row.names = FALSE
+    )
+    message("Done!")
+}
+
+if (sys.nframe() == 0) {
+    main()
+}

--- a/bin/metric-cellCycle.py
+++ b/bin/metric-cellCycle.py
@@ -4,7 +4,7 @@
 Evaluate integration using cell cycle conservation
 
 Usage:
-    metric-cellCycle.py --dataset=<str> --method=<str> --integration=<str> --exprs=<file> --out-file=<path> <file>
+    metric-cellCycle.py --dataset=<str> --method=<str> --integration=<str> --exprs=<file> --cc-genes=<file> --out-file=<path> <file>
 
 Options:
     -h --help            Show this screen.
@@ -12,11 +12,12 @@ Options:
     --method=<str>       Name of the method to calculate the metric for.
     --integration=<str>  Name of the integration to calculate the metric for.
     --exprs=<file>       Path to H5AD file containing the expression matrix.
+    --cc-genes=<file>    Path to TSV file containing cell cycle genes.
     --out-file=<path>    Path to output file.
 """
 
 
-def calculate_cellCycleConservation(adata, exprs):
+def calculate_cellCycleConservation(adata, exprs, s_genes, g2m_genes):
     """
     Calculate the cell cycle conservation score for an integrated dataset.
 
@@ -26,12 +27,17 @@ def calculate_cellCycleConservation(adata, exprs):
         AnnData object containing the integrated dataset
     exprs
         AnnData object containing the unintegrated dataset with the expression matrix
+    s_genes
+        List containing S phase genes
+    g2m_genes
+        List containing G2M phase genes
 
     Returns
     -------
     Cell cycle conservation score
     """
     from scib.metrics import cell_cycle
+    from scanpy.tools import score_genes_cell_cycle
 
     if adata.uns["Species"].lower() not in ["human", "mouse"]:
         from warnings import warn
@@ -41,6 +47,15 @@ def calculate_cellCycleConservation(adata, exprs):
         )
         return 1.0
 
+    print("Calculating batch cell cycle scores...")
+    batches = exprs.obs["Batch"].unique()
+    for batch in batches:
+        print(f"Batch '{batch}'")
+        exprs_batch = exprs[exprs.obs['Batch'] == batch].copy()
+        score_genes_cell_cycle(exprs_batch, s_genes, g2m_genes)
+        exprs.obs.loc[exprs_batch.obs_names, 'S_score'] = exprs_batch.obs['S_score']
+        exprs.obs.loc[exprs_batch.obs_names, 'G2M_score'] = exprs_batch.obs['G2M_score']
+
     print("Calculating cell cycle conservation score...")
     score = cell_cycle(
         adata_pre=exprs,
@@ -48,11 +63,70 @@ def calculate_cellCycleConservation(adata, exprs):
         batch_key="Batch",
         embed="X_emb",
         organism=adata.uns["Species"].lower(),
+        recompute_cc=False,
         verbose=True,
     )
-    print("Final score: {score}")
+    print(f"Final score: {score}")
 
     return score
+
+
+def read_cellcycle_genes(file, var_names, species):
+    """
+    Calculate the cell cycle conservation score for an integrated dataset.
+
+    Parameters
+    ----------
+    file
+        Path to TSV file containing cell cycle genes
+    var_names
+        List of the variable names for the dataset that will be scored
+    species
+        The species of the data to be scored, either 'human' or 'mouse'
+
+    Returns
+    -------
+    A tuple of lists of S phase genes and G2M phase genes
+    """
+
+    from pandas import read_csv
+
+    print(f"Reading cell cycle genes from '{file}'...")
+    genes_df = read_csv(file, sep="\t")
+
+    print(f"Selecting genes for species '{species}'...")
+    if species.lower() == "human":
+        genes_df = genes_df[genes_df["Species"] == "Human"]
+        ensembl_prefix = "ENSG"
+    elif species.lower() == "mouse":
+        genes_df = genes_df[genes_df["Species"] == "Mouse"]
+        ensembl_prefix = "ENSMUSG"
+    else:
+        from warnings import warn
+
+        warn(
+            f"'{species}' is not a valid species ('human', 'mouse'). Returning empty gene sets."
+        )
+        return ([], [])
+
+    is_ensembl = all(var_name.startswith(ensembl_prefix) for var_name in var_names)
+    if is_ensembl:
+        print(f"ENSEMBL var names detected, using ENSEMBL IDs")
+        id_col = "ENSEMBL"
+    else:
+        print("ENSEMBL var names not found, using gene names")
+        id_col = "Gene"
+
+    print("Selecting gene sets...")
+    genes_df = genes_df.dropna(subset=[id_col])
+    s_genes = list(genes_df[id_col][genes_df["Phase"] == "S"])
+    s_genes = [gene for gene in s_genes if gene in var_names]
+    print(f"Found {len(s_genes)} 'S' phase genes")
+    g2m_genes = list(genes_df[id_col][genes_df["Phase"] == "G2M"])
+    g2m_genes = [gene for gene in g2m_genes if gene in var_names]
+    print(f"Found {len(g2m_genes)} 'G2M' phase genes")
+
+    return (s_genes, g2m_genes)
 
 
 def main():
@@ -68,6 +142,7 @@ def main():
     method = args["--method"]
     integration = args["--integration"]
     exprs_file = args["--exprs"]
+    cc_file = args["--cc-genes"]
     out_file = args["--out-file"]
 
     print(f"Reading data from '{file}'...")
@@ -78,7 +153,8 @@ def main():
     exprs = read_h5ad(exprs_file)
     print("Read expression data:")
     print(exprs)
-    score = calculate_cellCycleConservation(input, exprs)
+    s_genes, g2m_genes = read_cellcycle_genes(cc_file, exprs.var_names, exprs.uns["Species"])
+    score = calculate_cellCycleConservation(input, exprs, s_genes, g2m_genes)
     output = format_metric_results(
         dataset, method, integration, "IntegrationBio", "CellCycle", score
     )

--- a/envs/biomaRt.yml
+++ b/envs/biomaRt.yml
@@ -1,0 +1,10 @@
+name: atlas-feature-selection-biomart
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconductor-biomart=2.54.0
+  - pip=22.2.2
+  - r-base=4.2.2
+  - r-docopt=0.7.1

--- a/main.nf
+++ b/main.nf
@@ -32,6 +32,14 @@ prepared_datasets_ch = Channel
         )
     }
 
+tirosh_genes_ch = Channel
+    .fromList(["tirosh-genes"])
+    .map { dataset ->
+        tuple(
+            file(params.outdir + "/datasets-raw/" + dataset + ".tsv"),
+        )
+    }
+
 features_ch = Channel
     .fromList(params.methods)
     .map { method ->
@@ -140,7 +148,7 @@ workflow WF_INTEGRATION {
 // WORKFLOW: Run metrics
 //
 workflow WF_METRICS {
-    METRICS(reference_ch, query_ch)
+    METRICS(reference_ch, query_ch, labels_ch, tirosh_genes_ch)
 }
 
 //
@@ -160,7 +168,8 @@ workflow WF_ALL {
     METRICS(
         INTEGRATION.out.reference_ch,
         INTEGRATION.out.query_ch,
-        INTEGRATION.out.labels_ch
+        INTEGRATION.out.labels_ch,
+        DATASETS.out.tirosh_genes_ch
     )
     REPORTS(METRICS.out)
 }

--- a/workflows/datasets.nf
+++ b/workflows/datasets.nf
@@ -6,6 +6,25 @@
 */
 
 
+process DATASET_TIROSH_GENES {
+    conda "envs/biomaRt.yml"
+
+    publishDir "$params.outdir/datasets-raw/"
+
+    output:
+        path("tirosh-genes.tsv")
+
+    script:
+        """
+        dataset-tirosh-genes.R --out-file "tirosh-genes.tsv"
+        """
+
+    stub:
+        """
+        touch tirosh-genes.tsv
+        """
+}
+
 process DATASET_TINYSIM {
     conda "envs/splatter.yml"
 
@@ -316,8 +335,11 @@ workflow DATASETS {
 
         PREPARE_DATASET(datasets_ch)
 
+        DATASET_TIROSH_GENES()
+
     emit:
         prepared_datasets_ch = PREPARE_DATASET.out
+        tirosh_genes_ch = DATASET_TIROSH_GENES.out
 }
 
 /*

--- a/workflows/metrics.nf
+++ b/workflows/metrics.nf
@@ -503,6 +503,7 @@ process METRIC_CELLCYCLE {
 
     input:
         tuple val(dataset), val(method), val(integration), path(reference), path(reference_exprs)
+        path(tirosh_genes)
         path(functions)
 
     output:
@@ -515,6 +516,7 @@ process METRIC_CELLCYCLE {
             --method "${method}" \\
             --integration "${integration}" \\
             --exprs "${reference_exprs}" \\
+            --cc-genes "${tirosh_genes}" \\
             --out-file "${dataset}-${method}-${integration}-cellCycle.tsv" \\
             ${reference}
         """
@@ -1222,6 +1224,7 @@ workflow METRICS {
         reference_ch
         query_ch
         labels_ch
+        tirosh_genes_ch
 
     main:
 
@@ -1285,7 +1288,7 @@ workflow METRICS {
             METRIC_ISOLATEDLABELSASW(reference_ch, py_metrics_funcs) :
             Channel.empty()
         cellCycle_ch = metric_names.contains("cellCycle") ?
-            METRIC_CELLCYCLE(reference_ch, py_metrics_funcs) :
+            METRIC_CELLCYCLE(reference_ch, tirosh_genes_ch, py_metrics_funcs) :
             Channel.empty()
         ldfDiff_ch = metric_names.contains("ldfDiff") ?
             METRIC_LDFDIFF(reference_ch, r_io_funcs, r_metrics_funcs) :


### PR DESCRIPTION
**Type of pull request**

- [ ] New dataset
- [ ] New method
- [ ] New metric
- [ ] Other feature
- [x] Bug fix
- [ ] Something else

**Description**

_Please describe the changes you have made_

Update the cell cycle metric to handle ENSEMBL IDs. This involves a new script, environment and Nextflow stage to read the Tirosh gene lists and add ENSEMBL IDs. The cell cycle metric script and stage are also updated to use this file as input. The script is also modified to manually calculate cell cycle scores rather than doing it using the scIB function. 

**Checklist**

_Please select those you have done, not everything is required_

- [x] Added a new script to `/bin`
- [x] Added a new environment to `/envs`
- [x] Added a new process to a workflow in `/workflows`
- [ ] Added a new entry to `conf/full-analysis.yml`
- [ ] Styled files using `style_bin.sh`
