### PR TITLE
Remove resampling in metric-reconstruction.py

### DIFF
--- a/bin/metric-reconstruction.py
+++ b/bin/metric-reconstruction.py
@@ -87,18 +87,15 @@ def calculate_reconstruction_error(model):
         batch_n = len(batch_indices)
         post_samples = np.zeros((batch_n, model.adata.shape[1]))
 
-        for i in tqdm(range(n_samples), desc="Sampling", leave=False):
-            post = np.zeros((batch_n, model.adata.shape[1]))
+        for _ in tqdm(range(n_samples), desc="Sampling", leave=False):
 
-            while np.any(post.sum(1) == 0):
-                post = model.posterior_predictive_sample(
-                    indices=batch_indices, n_samples=1
-                )
-                if np.any(post.sum(1) == 0):
-                    print("Posterior has cells with zero counts, resampling...")
+            post = model.posterior_predictive_sample(
+                indices=batch_indices, n_samples=1
+            )
 
             # Normalise the sample
             post = ((post.T / post.sum(1)).T) * 10000
+            post[~ np.isfinite(post)] = 0 # Reset all zero cells to 0
             post = np.log1p(post)
             # Add it to the sum over samples
             post_samples = post_samples + post

--- a/bin/metric-reconstruction.py
+++ b/bin/metric-reconstruction.py
@@ -89,13 +89,11 @@ def calculate_reconstruction_error(model):
 
         for _ in tqdm(range(n_samples), desc="Sampling", leave=False):
 
-            post = model.posterior_predictive_sample(
-                indices=batch_indices, n_samples=1
-            )
+            post = model.posterior_predictive_sample(indices=batch_indices, n_samples=1)
 
             # Normalise the sample
             post = ((post.T / post.sum(1)).T) * 10000
-            post[~ np.isfinite(post)] = 0 # Reset all zero cells to 0
+            post[~np.isfinite(post)] = 0  # Reset all zero cells to 0
             post = np.log1p(post)
             # Add it to the sum over samples
             post_samples = post_samples + post


### PR DESCRIPTION
**Type of pull request**

- [ ] New dataset
- [ ] New method
- [ ] New metric
- [ ] Other feature
- [x] Bug fix
- [ ] Something else

**Description**

_Please describe the changes you have made_

Was causing long/infinite run times for small numbers of features. All zero cells can be handled differently and should be rare over the 50 main samples so averages are not affected.

**Checklist**

_Please select those you have done, not everything is required_

- [ ] Added a new script to `/bin`
- [ ] Added a new environment to `/envs`
- [ ] Added a new process to a workflow in `/workflows`
- [ ] Added a new entry to `conf/full-analysis.yml`
- [x] Styled files using `style_bin.sh`
