### PR TITLE
Adjust distance metrics

### DIFF
--- a/bin/metric-cellDist.py
+++ b/bin/metric-cellDist.py
@@ -33,9 +33,8 @@ def calculate_cell_distance(reference, query):
     """
 
     from scipy.spatial.distance import mahalanobis
-    from scipy.stats import chi2
     from functions.distances import get_inverse_covariances, get_centroids
-    from numpy import mean
+    from numpy import mean, quantile
 
     reference_coords = reference.obsm["X_emb"]
     reference_labels = reference.obs["Label"].tolist()
@@ -45,12 +44,28 @@ def calculate_cell_distance(reference, query):
     print("Calculating centroid positions...")
     centroids = get_centroids(reference_coords, reference_labels)
 
-    print("Calculating cell Mahalonobis distances...")
-    distances = []
+    print("Calculating reference cell 90th quantile distances...")
+    ref_quantiles = {}
+    for label in set(reference_labels):
+        label_distances = []
+        label_reference = reference[reference.obs["Label"] == label].copy()
+
+        for idx in range(label_reference.n_obs):
+            label_coord = label_reference.obsm["X_emb"][idx, :]
+
+            distance = mahalanobis(
+                label_coord, centroids[label], inverse_covariances[label]
+            )
+            label_distances.append(distance)
+
+        ref_quantiles[label] = quantile(label_distances, 0.9)
+
+    print("Calculating cells outside 90th quantile...")
+    is_outside = []
     for idx in range(query.n_obs):
         query_label = query.obs["Label"][idx]
         # Skip labels that are not in the reference
-        if query_label not in inverse_covariances.keys():
+        if query_label not in set(reference_labels):
             continue
 
         query_coord = query.obsm["X_emb"][idx, :]
@@ -58,14 +73,13 @@ def calculate_cell_distance(reference, query):
         distance = mahalanobis(
             query_coord, centroids[query_label], inverse_covariances[query_label]
         )
-        distances.append(distance)
 
-    print("Calculating p-values...")
-    df = reference_coords.shape[1]
-    p_vals = [1 - chi2.cdf(dist, df=df) for dist in distances]
+        is_outside.append(distance > ref_quantiles[query_label])
 
     print("Calculating final score...")
-    score = mean(p_vals)
+    # The score is the proportion of cells outside the 90th quantile
+    # Subtract from 1 to get a higher score when cells fall inside the range
+    score = 1 - mean(is_outside)
 
     return score
 


### PR DESCRIPTION
Use scaled distances in Mahalanobis distance metrics instead of p-values. Changed as p-values were found to be uninformative.

**Type of pull request**

- [ ] New dataset
- [ ] New method
- [ ] New metric
- [ ] Other feature
- [ ] Bug fix
- [x] Something else

**Description**

_Please describe the changes you have made_

- For cell distance metrics, the 90th quantile of reference cells for each label is calculated and the score is the proportion of query cells that are closer than this distance (or further for unseen cell labels)
- For label distance metrics the maximum distance between the query label and query cells is calculated and used to scale the distance to reference labels.

**Checklist**

_Please select those you have done, not everything is required_

- [ ] Added a new script to `/bin`
- [ ] Added a new environment to `/envs`
- [ ] Added a new process to a workflow in `/workflows`
- [ ] Added a new entry to `conf/full-analysis.yml`
- [x] Styled files using `style_bin.sh`
